### PR TITLE
Do not set 'until-build' idea-version property on build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ apply plugin: 'java'
 
 intellij {
     version 'IC-2016.3' // https://www.jetbrains.com/intellij-repository/releases
+    updateSinceUntilBuild false
     pluginName 'nullability-annotations-inspection'
 
     publish {


### PR DESCRIPTION
By default, the intellij plugin will update the 'until-build' version
to be the same as the 'since-build' version.

For EAP users, this will prevent the plugin from being installed until
a new version of the plugin is released with an updated since and
until version.

Instead, do not automatically update the 'until-build' version, and
let the plugin be installed and fail gracefully at runtime if there
are any incompatibilities.