### PR TITLE
Add an option to ignore type-variable-typed declarations

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -27,7 +27,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="Java 1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -27,7 +27,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="Java 1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [0.0.10](https://github.com/stylismo/nullability-annotations-inspection/tree/0.0.10) (2017-11-22)
+[Full Changelog](https://github.com/stylismo/nullability-annotations-inspection/compare/0.0.9...0.0.10)
+
+**Implemented enhancements:**
+
+- Add option for ignoring type variable typed declarations [\#11](https://github.com/stylismo/nullability-annotations-inspection/issues/11)
+
 ## [0.0.9](https://github.com/stylismo/nullability-annotations-inspection/tree/0.0.9) (2017-09-12)
 [Full Changelog](https://github.com/stylismo/nullability-annotations-inspection/compare/0.0.8...0.0.9)
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ intellij {
 }
 
 group 'com.stylismo'
-version '0.0.9'
+version '0.0.10'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/stylismo/intellij/inspection/NullabilityAnnotationsInspection.java
+++ b/src/main/java/com/stylismo/intellij/inspection/NullabilityAnnotationsInspection.java
@@ -143,7 +143,6 @@ public class NullabilityAnnotationsInspection extends BaseJavaLocalInspectionToo
                                        InspectionManager manager,
                                        List<ProblemDescriptor> aProblemDescriptors) {
         if (!method.isConstructor()
-                && !(method.getReturnType() instanceof PsiPrimitiveType)
                 && !isIgnoredType(method.getReturnType())
                 && !hasAnnotation(method)) {
 

--- a/src/main/java/com/stylismo/intellij/inspection/NullabilityAnnotationsInspection.java
+++ b/src/main/java/com/stylismo/intellij/inspection/NullabilityAnnotationsInspection.java
@@ -16,6 +16,9 @@ import com.intellij.psi.PsiParameter;
 import com.intellij.psi.PsiPrimitiveType;
 import com.intellij.psi.PsiType;
 import com.intellij.psi.PsiTypeElement;
+import com.intellij.psi.PsiTypeParameter;
+import com.intellij.psi.PsiTypeVariable;
+import com.intellij.psi.impl.source.PsiClassReferenceType;
 import com.intellij.psi.util.MethodSignatureBackedByPsiMethod;
 import com.intellij.psi.util.TypeConversionUtil;
 import org.jetbrains.annotations.Nullable;
@@ -38,6 +41,7 @@ public class NullabilityAnnotationsInspection extends BaseJavaLocalInspectionToo
     private boolean reportInitializedStaticFinalFields = true;
     private boolean reportInitializedFinalFields = true;
     private boolean reportPrivateMethods = true;
+    private boolean reportTypeVariableTyped = true;
     private boolean removeRedundantAnnotations = true;
 
     @Nullable
@@ -116,6 +120,16 @@ public class NullabilityAnnotationsInspection extends BaseJavaLocalInspectionToo
     }
 
     @SuppressWarnings("WeakerAccess")
+    public boolean isReportTypeVariableTyped() {
+        return reportTypeVariableTyped;
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public void setReportTypeVariableTyped(boolean reportTypeVariableTyped) {
+        this.reportTypeVariableTyped = reportTypeVariableTyped;
+    }
+
+    @SuppressWarnings("WeakerAccess")
     public boolean isRemoveRedundantAnnotations() {
         return removeRedundantAnnotations;
     }
@@ -130,6 +144,7 @@ public class NullabilityAnnotationsInspection extends BaseJavaLocalInspectionToo
                                        List<ProblemDescriptor> aProblemDescriptors) {
         if (!method.isConstructor()
                 && !(method.getReturnType() instanceof PsiPrimitiveType)
+                && !isIgnoredType(method.getReturnType())
                 && !hasAnnotation(method)) {
 
             PsiTypeElement returnTypeElement = method.getReturnTypeElement();
@@ -182,6 +197,9 @@ public class NullabilityAnnotationsInspection extends BaseJavaLocalInspectionToo
     }
 
     private boolean shouldCheckField(PsiField field) {
+        if (isIgnoredType(field.getType())) {
+            return false;
+        }
         if (field.hasModifierProperty(FINAL)) {
             if (field.hasModifierProperty(STATIC)) {
                 return reportInitializedStaticFinalFields || !hasExpressionElement(field.getChildren());
@@ -219,7 +237,7 @@ public class NullabilityAnnotationsInspection extends BaseJavaLocalInspectionToo
     }
 
     private boolean parameterNeedsAnnotation(PsiParameter parameter) {
-        return !(parameter.getType() instanceof PsiPrimitiveType)
+        return !isIgnoredType(parameter.getType())
                 && !parameter.isVarArgs();
     }
 
@@ -233,5 +251,19 @@ public class NullabilityAnnotationsInspection extends BaseJavaLocalInspectionToo
 
     private boolean isNonPrivateMethod(PsiMethod method) {
         return reportPrivateMethods || !method.hasModifierProperty(PRIVATE);
+    }
+
+    /** Returns true if the type is a primitive or non-reportable type variable. */
+    private boolean isIgnoredType(@Nullable PsiType psiType) {
+        return psiType == null
+                || psiType instanceof PsiPrimitiveType
+                || !reportTypeVariableTyped && isTypeVariable(psiType);
+    }
+
+    /** Returns true if the type is a type variable or a type parameter reference. */
+    private static boolean isTypeVariable(@Nullable PsiType psiType) {
+        return psiType instanceof PsiTypeVariable
+                || psiType instanceof PsiClassReferenceType
+                && ((PsiClassReferenceType) psiType).resolve() instanceof PsiTypeParameter;
     }
 }

--- a/src/main/java/com/stylismo/intellij/inspection/OptionsPanel.java
+++ b/src/main/java/com/stylismo/intellij/inspection/OptionsPanel.java
@@ -21,6 +21,7 @@ class OptionsPanel extends JPanel {
             new JCheckBox("Check initialized static final fields");
     private final JCheckBox shouldCheckInitializedFinalFields = new JCheckBox("Check initialized final fields");
     private final JCheckBox shouldCheckPrivateMethods = new JCheckBox("Check private methods");
+    private final JCheckBox shouldCheckTypeVariableTyped = new JCheckBox("Check type variable typed declarations");
     private final JCheckBox shouldRemoveRedundantAnnotations =
             new JCheckBox("Remove redundant annotations after applying 'default' to package");
     private final NullabilityAnnotationsInspection owner;
@@ -40,6 +41,7 @@ class OptionsPanel extends JPanel {
         shouldCheckInitializedStaticFinalFields.addActionListener(actionListener);
         shouldCheckInitializedFinalFields.addActionListener(actionListener);
         shouldCheckPrivateMethods.addActionListener(actionListener);
+        shouldCheckTypeVariableTyped.addActionListener(actionListener);
         shouldRemoveRedundantAnnotations.addActionListener(actionListener);
 
         JButton openConfigureAnnotationsDialogButton = new JButton("Configure annotations");
@@ -65,12 +67,14 @@ class OptionsPanel extends JPanel {
                 new GridConstraints(2, 0, 1, 1, 8, 0, 3, 0, null, null, null, 2));
         panel.add(shouldCheckPrivateMethods,
                 new GridConstraints(3, 0, 1, 1, 8, 0, 3, 0, null, null, null, 0));
+        panel.add(shouldCheckTypeVariableTyped,
+                new GridConstraints(4, 0, 1, 1, 8, 0, 3, 0, null, null, null, 0));
 
         panel.add(shouldRemoveRedundantAnnotations,
-                new GridConstraints(5, 0, 1, 1, 8, 0, 3, 0, null, null, null, 0));
+                new GridConstraints(6, 0, 1, 1, 8, 0, 3, 0, null, null, null, 0));
 
         panel.add(openConfigureAnnotationsDialogButton,
-                new GridConstraints(7, 0, 1, 1, 8, 0, 0, 0, null, null, null, 0));
+                new GridConstraints(8, 0, 1, 1, 8, 0, 0, 0, null, null, null, 0));
 
         add(panel, BorderLayout.CENTER);
 
@@ -84,6 +88,7 @@ class OptionsPanel extends JPanel {
         shouldCheckInitializedFinalFields.setSelected(owner.isReportInitializedFinalFields());
         shouldCheckInitializedFinalFields.setEnabled(owner.isReportFields());
         shouldCheckPrivateMethods.setSelected(owner.isReportPrivateMethods());
+        shouldCheckTypeVariableTyped.setSelected(owner.isReportTypeVariableTyped());
         shouldRemoveRedundantAnnotations.setSelected(owner.isRemoveRedundantAnnotations());
     }
 
@@ -94,6 +99,7 @@ class OptionsPanel extends JPanel {
         shouldCheckInitializedFinalFields.setEnabled(owner.isReportFields());
         owner.setReportInitializedFinalFields(shouldCheckInitializedFinalFields.isSelected());
         owner.setReportPrivateMethods(shouldCheckPrivateMethods.isSelected());
+        owner.setReportTypeVariableTyped(shouldCheckTypeVariableTyped.isSelected());
         owner.setRemoveRedundantAnnotations(shouldRemoveRedundantAnnotations.isSelected());
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -37,7 +37,7 @@
     ]]></description>
 
     <change-notes><![CDATA[
-<a href="https://github.com/stylismo/nullability-annotations-inspection/releases/tag/0.0.9"><h3>Changes in 0.0.9</h3></a> (2017-09-12)
+<a href="https://github.com/stylismo/nullability-annotations-inspection/releases/tag/0.0.10"><h3>Changes in 0.0.10</h3></a> (2017-09-12)
 <br/>
 <br/>
 <ul>


### PR DESCRIPTION
This implements #11 feature request.

I manually checked that it works with `./gradlew runIdea` yet couldn't figure out how to add a test case to the project.